### PR TITLE
ENH: Create a single container class for Imaging's subclasses

### DIFF
--- a/app/AcquireIntersonArrayBMode.xml
+++ b/app/AcquireIntersonArrayBMode.xml
@@ -32,6 +32,14 @@
       <default>1</default>
     </integer>
     <integer>
+      <name>focusIndex</name>
+      <label>Focus Index</label>
+      <description>Index of the focus to examine.  See the output of PrintIntersonProbeInfo.</description>
+      <longflag>focusIndex</longflag>
+      <flag>F</flag> 
+      <default>0</default>
+    </integer>
+    <integer>
       <name>highVoltage</name>
       <label>High Voltage</label>
       <description>Percentage of the high voltage for transducer excitation.</description>
@@ -61,12 +69,5 @@
       <minimum>0</minimum>
       <maximum>200</maximum>
     </integer>
-    <boolean>
-      <name>scanConvert</name>
-      <label>Scan Convert</label>
-      <description>Do scan conversion.</description>
-      <longflag>scanConvert</longflag>
-      <flag>s</flag>
-    </boolean>
   </parameters>
 </executable>

--- a/app/AcquireIntersonArrayRF.cxx
+++ b/app/AcquireIntersonArrayRF.cxx
@@ -1,16 +1,38 @@
+/*=========================================================================
+
+Library:   IntersonArray
+
+Copyright Kitware Inc. 28 Corporate Drive,
+Clifton Park, NY, 12065, USA.
+
+All rights reserved.
+
+Licensed under the Apache License, Version 2.0 ( the "License" );
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=========================================================================*/
 #include <Windows.h> // Sleep
 
 #include "itkImageFileWriter.h"
 
-#include "IntersonCxxImagingScan2DClass.h"
-#include "IntersonCxxControlsHWControls.h"
+#include "IntersonArrayCxxImagingContainer.h"
+#include "IntersonArrayCxxControlsHWControls.h"
 
-#include "AcquireIntersonRFCLP.h"
+#include "AcquireIntersonArrayRFCLP.h"
 
-typedef IntersonCxx::Imaging::Scan2DClass Scan2DClassType;
+typedef IntersonArrayCxx::Imaging::Container ContainerType;
 
 const unsigned int Dimension = 3;
-typedef Scan2DClassType::RFPixelType       PixelType;
+typedef ContainerType::RFPixelType         PixelType;
 typedef itk::Image< PixelType, Dimension > ImageType;
 
 
@@ -22,25 +44,29 @@ struct CallbackClientData
 
 void __stdcall pasteIntoImage( PixelType * buffer, void * clientData )
 {
-  CallbackClientData * callbackClientData = static_cast< CallbackClientData * >( clientData );
-  ImageType * image = callbackClientData->Image;
+  CallbackClientData * callbackClientData =
+    static_cast< CallbackClientData * >( clientData );
+  ImageType * image =
+    callbackClientData->Image;
 
-  const ImageType::RegionType & largestRegion = image->GetLargestPossibleRegion();
+  const ImageType::RegionType & largestRegion =
+    image->GetLargestPossibleRegion();
+  const ImageType::SizeType imageSize = largestRegion.GetSize();
   const itk::SizeValueType imageFrames = largestRegion.GetSize()[2];
   if( callbackClientData->FrameIndex >= imageFrames )
     {
     return;
     }
 
-  const int maxVectors = Scan2DClassType::MAX_VECTORS;
-  const int maxSamples = Scan2DClassType::MAX_RFSAMPLES;
-  const int framePixels = maxVectors * maxSamples;
+  const int framePixels = imageSize[0] * imageSize[1];
+  std::cout << "frame pixels = " << framePixels << std::endl;
 
   PixelType * imageBuffer = image->GetPixelContainer()->GetBufferPointer();
   imageBuffer += framePixels * callbackClientData->FrameIndex;
   std::memcpy( imageBuffer, buffer, framePixels * sizeof( PixelType ) );
 
-  std::cout << "Acquired frame: " << callbackClientData->FrameIndex << std::endl;
+  std::cout << "Acquired frame: " << callbackClientData->FrameIndex
+    << std::endl;
   ++(callbackClientData->FrameIndex);
 }
 
@@ -48,11 +74,10 @@ int main( int argc, char * argv[] )
 {
   PARSE_ARGS;
 
+  typedef IntersonArrayCxx::Controls::HWControls HWControlsType;
+  IntersonArrayCxx::Controls::HWControls hwControls;
 
-  typedef IntersonCxx::Controls::HWControls HWControlsType;
-  IntersonCxx::Controls::HWControls hwControls;
-
-  Scan2DClassType scan2D;
+  ContainerType container;
 
   typedef HWControlsType::FoundProbesType FoundProbesType;
   FoundProbesType foundProbes;
@@ -72,9 +97,29 @@ int main( int argc, char * argv[] )
 
   int ret = EXIT_SUCCESS;
 
+  int steering = 0;
+
+  const int width = hwControls.GetLinesPerArray();
+  const int height = ContainerType::MAX_RFSAMPLES;
+  if( hwControls.ValidDepth( depth ) == depth )
+    {
+    ContainerType::ScanConverterError converterError =
+      container.HardInitScanConverter( depth, width, height, steering );
+    if( converterError != ContainerType::SUCCESS )
+      {
+      std::cerr << "Error during hard scan converter initialization: "
+                << converterError << std::endl;
+      return EXIT_FAILURE;
+      }
+    }
+  else
+    {
+    std::cerr << "Invalid requested depth for probe." << std::endl;
+    }
+
   const itk::SizeValueType framesToCollect = frames;
-  const int maxVectors = Scan2DClassType::MAX_VECTORS;
-  const int maxSamples = Scan2DClassType::MAX_RFSAMPLES;
+  const int maxVectors = hwControls.GetLinesPerArray();
+  const int maxSamples = ContainerType::MAX_RFSAMPLES;
 
   ImageType::Pointer image = ImageType::New();
   typedef ImageType::RegionType RegionType;
@@ -94,17 +139,16 @@ int main( int argc, char * argv[] )
   clientData.Image = image.GetPointer();
   clientData.FrameIndex = 0;
 
-  scan2D.SetNewRFImageCallback( &pasteIntoImage, &clientData );
-
   HWControlsType::FrequenciesType frequencies;
   hwControls.GetFrequency( frequencies );
-  if( !hwControls.SetFrequency( frequencies[frequencyIndex] ) )
+  if( !hwControls.SetFrequencyAndFocus( frequencyIndex, focusIndex,
+      steering ) )
     {
-    std::cerr << "Could not set the frequency." << std::endl;
+    std::cerr << "Could not set the frequency and focus." << std::endl;
     return EXIT_FAILURE;
     }
 
-  if( !hwControls.SendHighVoltage( highVoltage ) )
+  if( !hwControls.SendHighVoltage( highVoltage, highVoltage ) )
     {
     std::cerr << "Could not set the high voltage." << std::endl;
     return EXIT_FAILURE;
@@ -115,50 +159,58 @@ int main( int argc, char * argv[] )
     return EXIT_FAILURE;
     }
 
-  if( decimator )
-    {
-    if( !hwControls.EnableRFDecimator() )
-      {
-      std::cerr << "Could not enable RF decimator." << std::endl;
-      return EXIT_FAILURE;
-      }
-    }
-  else
-    {
-    if( !hwControls.DisableRFDecimator() )
-      {
-      std::cerr << "Could not disable RF decimator." << std::endl;
-      return EXIT_FAILURE;
-      }
-    }
-
   hwControls.DisableHardButton();
 
-  scan2D.AbortScan();
-  scan2D.SetRFData( true );
-  if( !hwControls.StartMotor() )
+  std::cout << "Acquire 1 bmode image" << std::endl;
+  container.AbortScan();
+  container.SetRFData( false );
+  container.StartReadScan();
+  if( !hwControls.StartBmode() )
     {
-    std::cerr << "Could not start motor." << std::endl;
+    std::cerr << "Could not start RF collection." << std::endl;
     return EXIT_FAILURE;
-    };
-  scan2D.StartRFReadScan();
+    }
+  Sleep( 100 );
+  Sleep( 100 );
+  Sleep( 100 );
+  Sleep( 100 );
+  std::cout << "StopAcquisition" << std::endl;
+  hwControls.StopAcquisition();
+  container.StopReadScan();
+  Sleep( 100 ); // "time to stop"
+  container.DisposeScan();
+
+  container.SetNewRFImageCallback( &pasteIntoImage, &clientData );
+
+  std::cout << "SetRFData" << std::endl;
+  container.SetRFData( true );
+  std::cout << "StartRFReadScan" << std::endl;
+  container.StartRFReadScan();
   Sleep( 100 ); // "time to start"
+  std::cout << "StartRFmode" << std::endl;
   if( !hwControls.StartRFmode() )
     {
     std::cerr << "Could not start RF collection." << std::endl;
     return EXIT_FAILURE;
-    };
-
-  while( clientData.FrameIndex < framesToCollect )
-    {
-    Sleep( 100 );
     }
 
+  /*  BUG: FrameIndex never changes, since callback
+   *  never happens with RF data. */
+  int c = 0;
+  while( clientData.FrameIndex < framesToCollect && c < 100 )
+    {
+    std::cout << clientData.FrameIndex << " of " << framesToCollect
+      << std::endl;
+    std::cout << c << " of 100" << std::endl;
+    Sleep( 100 );
+    ++c;
+    }
+
+  std::cout << "StopAcquisition" << std::endl;
   hwControls.StopAcquisition();
-  scan2D.StopReadScan();
+  container.StopReadScan();
   Sleep( 100 ); // "time to stop"
-  scan2D.DisposeScan();
-  hwControls.StopMotor();
+  container.DisposeScan();
 
   typedef itk::ImageFileWriter< ImageType > WriterType;
   WriterType::Pointer writer = WriterType::New();

--- a/app/AcquireIntersonArrayRF.xml
+++ b/app/AcquireIntersonArrayRF.xml
@@ -32,6 +32,14 @@
       <default>1</default>
     </integer>
     <integer>
+      <name>focusIndex</name>
+      <label>Focus Index</label>
+      <description>Index of the focus to examine.  See the output of PrintIntersonProbeInfo.</description>
+      <longflag>focusIndex</longflag>
+      <flag>F</flag> 
+      <default>0</default>
+    </integer>
+    <integer>
       <name>highVoltage</name>
       <label>High Voltage</label>
       <description>Percentage of the high voltage for transducer excitation.</description>
@@ -41,13 +49,16 @@
       <minimum>0</minimum>
       <maximum>100</maximum>
     </integer>
-    <boolean>
-      <name>decimator</name>
-      <label>Enable RF Decimator</label>
-      <description>For GV and GP (low frequency probes) sampling rate is 15 Msamples/sec with decimator off and with decimator on sampling rate is 7.5 Msamples/sec. For higher frequency probes sampling rate is 30 Ms/sec with decimator off and 15 Ms/sec with decimator on.</description>
-      <longflag>decimator</longflag>
+    <integer>
+      <name>depth</name>
+      <label>Depth</label>
+      <description>Depth of acquisition [mm]. Only relevant with scanConvert.</description>
+      <longflag>depth</longflag>
       <flag>d</flag>
-    </boolean>
+      <default>40</default>
+      <minimum>0</minimum>
+      <maximum>200</maximum>
+    </integer>
 
   </parameters>
 </executable>

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -71,19 +71,6 @@ if( BUILD_TESTING )
       --gain 50
       ${TEMP}/AcquireIntersonArrayBModeTestGain.mha
      )
-  add_test( NAME AcquireIntersonArrayBModeTestScanConvert
-    COMMAND $<TARGET_FILE:AcquireIntersonArrayBMode>
-      --scanConvert
-      --gain 50
-      ${TEMP}/AcquireIntersonArrayBModeTestScanConvert.mha
-     )
-  add_test( NAME AcquireIntersonArrayBModeTestScanConvertFrames
-    COMMAND $<TARGET_FILE:AcquireIntersonArrayBMode>
-      -s
-      -n 4
-      --gain 50
-      ${TEMP}/AcquireIntersonArrayBModeTestScanConvertFrames.mha
-     )
 
   add_test( NAME AcquireIntersonArrayRFTest
     COMMAND $<TARGET_FILE:AcquireIntersonArrayRF>
@@ -99,12 +86,6 @@ if( BUILD_TESTING )
       --highVoltage 30
       ${TEMP}/AcquireIntersonArrayRFTestVoltage.mha
      )
-  add_test( NAME AcquireIntersonArrayRFTestDecimator
-    COMMAND $<TARGET_FILE:AcquireIntersonArrayRF>
-      --decimator
-      ${TEMP}/AcquireIntersonArrayRFTestDecimator.mha
-     )
-
   add_test( NAME PrintIntersonArrayProbeInfoTest
     COMMAND $<TARGET_FILE:PrintIntersonArrayProbeInfo>
      )

--- a/app/PrintIntersonArrayProbeInfo.cxx
+++ b/app/PrintIntersonArrayProbeInfo.cxx
@@ -21,7 +21,9 @@ limitations under the License.
 
 =========================================================================*/
 #include "IntersonArrayCxxControlsHWControls.h"
-#include "IntersonArrayCxxIntersonClass.h"
+
+#include <cstdlib>
+#include <iostream>
 
 #include "PrintIntersonArrayProbeInfoCLP.h"
 
@@ -29,8 +31,13 @@ int main( int argc, char * argv[] )
 {
   PARSE_ARGS;
 
+  std::cout << "Start---" << std::endl;
   typedef IntersonArrayCxx::Controls::HWControls HWControlsType;
+
   IntersonArrayCxx::Controls::HWControls hwControls;
+ 
+  std::cout << "ProbeID: " << static_cast< int >(
+    hwControls.GetProbeID() ) << std::endl;
 
   typedef HWControlsType::FoundProbesType FoundProbesType;
   FoundProbesType foundProbes;
@@ -40,7 +47,7 @@ int main( int argc, char * argv[] )
     std::cerr << "Could not find the probe." << std::endl;
     return EXIT_FAILURE;
     }
-  std::cout << "\nProbes Found: " << std::endl;
+  std::cout << "Probes Found: " << std::endl;
   for( size_t ii = 0; ii < foundProbes.size(); ++ii )
     {
     std::cout << "    " << ii << ": " << foundProbes[ii] << std::endl;
@@ -66,22 +73,40 @@ int main( int argc, char * argv[] )
     std::cout << "    " << ii << ": " << frequencies[ii] << std::endl;
     }
 
+  HWControlsType::FocusType focus;
+  hwControls.GetFocus( focus );
+  std::cout << "\nFocus: [mm]" << std::endl;
+  for( size_t ii = 0; ii < focus.size(); ++ii )
+    {
+    std::cout << "    " << ii << ": " << focus[ii] << std::endl;
+    }
+
   std::cout << "\nSupported Depth [mm]: FrameRate [fps]" << std::endl;
   int depth = 20;
   while( hwControls.ValidDepth( depth ) == depth )
     {
-    short frameRate = hwControls.GetProbeFrameRate( depth );
+    short frameRate = hwControls.GetProbeFrameRate();
     std::cout << "    " << depth << ":\t" << frameRate << std::endl;
     depth += 20;
     }
 
-  std::cout << "\nSerial number: " << hwControls.GetProbeSerialNumber() << std::endl;
-  std::cout << "FPGA Version:  " << hwControls.ReadFPGAVersion() << std::endl;
+  std::cout << "Lines per array = " << hwControls.GetLinesPerArray()
+    << std::endl;
+  std::cout << "Array CompoundAngle = " << hwControls.GetCompoundAngle()
+    << std::endl;
+  std::cout << "Array Radius = " << hwControls.GetArrayRadius()
+    << std::endl;
+  std::cout << "Array Angle = " << hwControls.GetArrayAngle()
+    << std::endl;
+  std::cout << "Array Width = " << hwControls.GetArrayWidth()
+    << std::endl;
+
+  std::cout << "\nSerial number: " << hwControls.GetProbeSerialNumber()
+    << std::endl;
+  std::cout << "FPGA Version:  " << hwControls.ReadFPGAVersion()
+    << std::endl;
   std::cout << "OEM ID:        " << hwControls.GetOEMId() << std::endl;
   std::cout << "Filter ID:     " << hwControls.GetFilterId() << std::endl;
-
-  IntersonArrayCxx::IntersonClass intersonClass;
-  std::cout << "SDK Version:   " << intersonClass.Version() << std::endl;
 
   return EXIT_SUCCESS;
 }

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -22,6 +22,7 @@
 ##############################################################################
 set( IntersonArrayCxx_HEADERS
   IntersonArrayCxxControlsHWControls.h
+  IntersonArrayCxxImagingContainer.h
   IntersonArrayCxxImagingCapture.h
   IntersonArrayCxxImagingImageBuilding.h
   IntersonArrayCxxImagingScanConverter.h

--- a/include/IntersonArrayCxxControlsHWControls.h
+++ b/include/IntersonArrayCxxControlsHWControls.h
@@ -169,10 +169,10 @@ public:
   //To get the identification of the filter.
   std::string GetFilterId() const;
 
-  bool DoReadOEMEEPROM( unsigned char & bytDataStage, unsigned short addr,
+  bool DoReadOEMEEPROM( unsigned char * bytDataStage, unsigned short addr,
     unsigned short length );
 
-  bool DoWriteOEMEEPROM( unsigned char & bytDataStage, unsigned short addr,
+  bool DoWriteOEMEEPROM( unsigned char * bytDataStage, unsigned short addr,
     unsigned short length );
 
 

--- a/include/IntersonArrayCxxImagingContainer.h
+++ b/include/IntersonArrayCxxImagingContainer.h
@@ -1,0 +1,134 @@
+/*=========================================================================
+
+Library:   IntersonArray
+
+Copyright Kitware Inc. 28 Corporate Drive,
+Clifton Park, NY, 12065, USA.
+
+All rights reserved.
+
+Licensed under the Apache License, Version 2.0 ( the "License" );
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=========================================================================*/
+#ifndef _IntersonArrayCxxImagingContainer_h
+#define _IntersonArrayCxxImagingContainer_h
+
+#include "IntersonArrayCxx_Export.h"
+
+#include <string>
+#include <vector>
+
+namespace IntersonArrayCxx
+{
+
+namespace Imaging
+{
+
+class ContainerImpl;
+
+class IntersonArrayCxx_EXPORT Container
+{
+public:
+  Container();
+  ~Container();
+
+  typedef unsigned char  PixelType;
+  typedef unsigned short RFPixelType;
+
+  static const int MAX_SAMPLES = 1024;
+  static const int MAX_RFSAMPLES = 2048;
+
+  bool GetCompound();
+
+  void SetCompound( bool value );
+
+  bool GetDoubler();
+
+  void SetDoubler( bool value );
+
+  int GetHeightScan() const;
+
+  float GetMmPerPixel() const;
+
+  double GetTrueDepth() const;
+
+  int GetWidthScan() const;
+
+  int GetZeroOfYScale() const;
+
+  // Error code of HardInitScanConverter and SoftInitScanConverter
+  enum ScanConverterError
+  {
+    SUCCESS = 1,
+    PROBE_NOT_INITIALIZED, // FindMyProbe has not been called
+    UNKNOWN_PROBE, // Probe Identity not valid
+    UNDER_LIMITS, // Width * Height over 10 * 10
+    OVER_LIMITS, // Width * Height over 800 * 1000
+    WRONG_FORMAT, // other error
+    OTHER_ERROR
+  };
+
+  ScanConverterError HardInitScanConverter( int depth, int widthScan,
+    int heightScan, int steering );
+
+  ScanConverterError IdleInitScanConverter( int depth, int width,
+    int height, short idleId, int idleSteering, bool idleDoubler,
+    bool idleCompound, int idleCompoundAngle );
+  
+  //
+  // Begin Capture Methods
+  //
+  bool GetRFData();
+
+  void SetRFData( bool value );
+
+  bool GetFrameAvg();
+
+  void SetFrameAvg( bool value );
+
+  bool GetScanOn() const;
+
+  void AbortScan();
+
+  void DisposeScan();
+
+  void StartReadScan();
+
+  void StartRFReadScan();
+
+  void StopReadScan();
+
+  typedef void (__stdcall *NewImageCallbackType)( PixelType *buffer,
+    void *clientData );
+  void SetNewImageCallback( NewImageCallbackType callback,
+    void *clientData = NULL );
+
+  typedef void (__stdcall *NewRFImageCallbackType)( RFPixelType *buffer,
+    void *clientData );
+  void SetNewRFImageCallback( NewRFImageCallbackType callback,
+    void *clientData = NULL );
+
+private:
+
+  Container( const Container &);
+  void operator=( const Container &);
+
+  ContainerImpl *Impl;
+};
+
+} // end namespace Imaging
+
+} // end namespace IntersonArrayCxx
+
+
+#endif // _IntersonArrayCxxImagingContainer_h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,6 +32,7 @@ set( COMPILE_FLAGS "/clr /EHa /AI${IntersonArraySDK_DIR}/Libraries" )
 
 set( IntersonArrayCxx_SRCS
   IntersonArrayCxxControlsHWControls.cxx
+  IntersonArrayCxxImagingContainer.cxx
   IntersonArrayCxxImagingCapture.cxx
   IntersonArrayCxxImagingImageBuilding.cxx
   IntersonArrayCxxImagingScanConverter.cxx
@@ -62,5 +63,15 @@ if( BUILD_TESTING )
   add_custom_command( TARGET IntersonArrayCxx
     POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_if_different "${IntersonArraySDK_DIR}/Libraries/IntersonArray.dll" "${PROJECT_BINARY_DIR}/bin"
+    )
+endif()
+if( BUILD_APPLICATIONS )
+  add_custom_command( TARGET IntersonArrayCxx
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${IntersonArraySDK_DIR}/Libraries/IntersonArray.dll" "${PROJECT_BINARY_DIR}/app/bin"
+    )
+  add_custom_command( TARGET IntersonArrayCxx
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${PROJECT_BINARY_DIR}/bin/IntersonArrayCxx.dll" "${PROJECT_BINARY_DIR}/app/bin"
     )
 endif()

--- a/src/IntersonArrayCxxControlsHWControls.cxx
+++ b/src/IntersonArrayCxxControlsHWControls.cxx
@@ -314,6 +314,38 @@ public:
       IntersonArray::Controls::HWControls::GetFilterId() );
   }
 
+  bool DoReadOEMEEPROM( unsigned char * bytDataStage, unsigned short addr,
+    unsigned short length ) 
+  {
+    typedef cli::array< unsigned char, 1 >  DataType;
+    DataType ^ managedData;
+
+    if( Wrapped->DoReadOEMEEPROM( managedData, addr, length ) )
+      {
+      bytDataStage = new unsigned char[ length ];
+      for( unsigned int ii=0; ii<length; ++ii )
+        {
+        bytDataStage[ii] = managedData[ii];
+        }
+      return true;
+      }
+    return false;
+  }
+
+  bool DoWriteOEMEEPROM( unsigned char * bytDataStage, unsigned short addr,
+    unsigned short length ) 
+  {
+    typedef cli::array< unsigned char, 1 >  DataType;
+    DataType ^ managedData;
+
+    for( unsigned int ii=0; ii<length; ++ii )
+      {
+      managedData[ii] = bytDataStage[ii];
+      }
+
+    return Wrapped->DoWriteOEMEEPROM( managedData, addr, length );
+  }
+
 
 private:
 
@@ -341,6 +373,46 @@ HWControls
 }
 
 
+int
+HWControls
+::GetCompoundAngle() const
+{
+  return Impl->GetCompoundAngle();
+}
+
+
+bool
+HWControls
+::EnableCompound()
+{
+  return Impl->EnableCompound();
+}
+
+
+bool
+HWControls
+::DisableCompound()
+{
+  return Impl->DisableCompound();
+}
+
+
+bool
+HWControls
+::EnableDoubler()
+{
+  return Impl->EnableDoubler();
+}
+
+
+bool
+HWControls
+::DisableDoubler()
+{
+  return Impl->DisableDoubler();
+}
+
+
 short
 HWControls
 ::GetProbeID() const
@@ -364,6 +436,39 @@ HWControls
   Impl->FindMyProbe( probeIndex );
 }
 
+
+float
+HWControls
+::GetArrayAngle() const
+{
+  return Impl->GetArrayAngle();
+}
+
+
+float
+HWControls
+::GetArrayRadius() const
+{
+  return Impl->GetArrayRadius();
+}
+
+
+float
+HWControls
+::GetArrayWidth() const
+{
+  return Impl->GetArrayWidth();
+}
+
+
+void
+HWControls
+::GetFocus( FocusType &focus ) const
+{
+  Impl->GetFocus( focus );
+}
+
+
 int
 HWControls
 ::ValidDepth( int depth ) const
@@ -380,20 +485,20 @@ HWControls
 }
 
 
-void
-HWControls
-::GetFocus( FocusType &focus ) const
-{
-  Impl->GetFocus( focus );
-}
-
-
 bool
 HWControls
 ::SetFrequencyAndFocus( unsigned char frequency, unsigned char focus,
   int steering )
 {
   return Impl->SetFrequencyAndFocus( frequency, focus, steering );
+}
+
+
+unsigned int
+HWControls
+::GetLinesPerArray() const
+{
+  return Impl->GetLinesPerArray();
 }
 
 
@@ -452,6 +557,13 @@ HWControls
   return Impl->ReadHardButton();
 }
 
+void
+HWControls
+::SetNewHardButtonCallback( HWControls::NewHardButtonCallbackType callback,
+    void * clientData )
+{
+  Impl->SetNewHardButtonCallback( callback, clientData );
+}
 
 bool
 HWControls
@@ -511,9 +623,34 @@ HWControls
 
 std::string
 HWControls
+::Get3DId() const
+{
+  return Impl->Get3DId();
+}
+
+
+std::string
+HWControls
 ::GetFilterId() const
 {
   return Impl->GetFilterId();
+}
+
+
+bool
+HWControls
+::DoReadOEMEEPROM( unsigned char * bytDataStage, unsigned short addr,
+  unsigned short length ) 
+{
+  return Impl->DoReadOEMEEPROM( bytDataStage, addr, length );
+}
+
+bool
+HWControls
+::DoWriteOEMEEPROM( unsigned char * bytDataStage, unsigned short addr,
+  unsigned short length ) 
+{
+  return Impl->DoWriteOEMEEPROM( bytDataStage, addr, length );
 }
 
 } // end namespace Controls

--- a/src/IntersonArrayCxxImagingCapture.cxx
+++ b/src/IntersonArrayCxxImagingCapture.cxx
@@ -23,15 +23,13 @@ limitations under the License.
 #pragma unmanaged
 #include "IntersonArrayCxxImagingCapture.h"
 #include "IntersonArrayCxxImagingScanConverter.h"
+#include "IntersonArrayCxxControlsHWControls.h"
 #pragma managed
 
 #include <vcclr.h>
 #include <msclr/marshal_cppstd.h>
 
 #using "IntersonArray.dll"
-
-// for Bitmap
-#using "System.Drawing.dll"
 
 namespace IntersonArrayCxx
 {
@@ -52,8 +50,7 @@ public:
     NewRFImageCallback( NULL ),
     NewRFImageCallbackClientData( NULL ),
     NativeRFBuffer( new RFPixelType[ScanConverter::MAX_RFSAMPLES
-      * 512] ),
-      //* ScanConverter::MAX_VECTORS]
+      * ScanConverter::MAX_RFSAMPLES] ),
     ManagedRFBuffer( managedRFBuffer )
   {
   }
@@ -68,8 +65,7 @@ public:
   {
     if ( this->NewRFImageCallback != NULL )
     {
-      //for ( int ii = 0; ii < ScanConverter::MAX_VECTORS; ++ii )
-      for ( int ii = 0; ii < 512; ++ii )
+      for ( int ii = 0; ii < ScanConverter::MAX_RFSAMPLES; ++ii )
       {
         for ( int jj = 0; jj < ScanConverter::MAX_RFSAMPLES; ++jj )
         {
@@ -93,7 +89,7 @@ private:
   NewRFImageCallbackType   NewRFImageCallback;
   void                   * NewRFImageCallbackClientData;
   RFPixelType            * NativeRFBuffer;
-  RFArrayType             ^ManagedRFBuffer;
+  RFArrayType            ^ ManagedRFBuffer;
 };
 
 
@@ -109,8 +105,7 @@ public:
     NewImageCallback( NULL ),
     NewImageCallbackClientData( NULL ),
     NativeBuffer( new PixelType[ScanConverter::MAX_SAMPLES *
-      512] ),
-      //ScanConverter::MAX_VECTORS] ),
+      ScanConverter::MAX_SAMPLES] ),
     ManagedBuffer( managedBuffer )
   {
   }
@@ -125,12 +120,11 @@ public:
   {
     if ( this->NewImageCallback != NULL )
     {
-      for ( int ii = 0; ii < 512; ++ii )
-      //for ( int ii = 0; ii < ScanConverter::MAX_VECTORS; ++ii )
+      for ( int ii = 0; ii < ScanConverter::MAX_RFSAMPLES; ++ii )
       {
-        for ( int jj = 0; jj < ScanConverter::MAX_SAMPLES; ++jj )
+        for ( int jj = 0; jj < ScanConverter::MAX_RFSAMPLES; ++jj )
         {
-          this->NativeBuffer[ScanConverter::MAX_SAMPLES * ii + jj] =
+          this->NativeBuffer[ScanConverter::MAX_RFSAMPLES * ii + jj] =
             this->ManagedBuffer[ii, jj];
         }
       }
@@ -150,7 +144,7 @@ private:
   NewImageCallbackType   NewImageCallback;
   void                 * NewImageCallbackClientData;
   PixelType            * NativeBuffer;
-  ArrayType             ^ManagedBuffer;
+  ArrayType            ^ ManagedBuffer;
 };
 
 
@@ -167,17 +161,15 @@ public:
   {
     Wrapped = gcnew IntersonArray::Imaging::Capture();
 
-    //Buffer = gcnew ArrayType( ScanConverter::MAX_VECTORS,
-    Buffer = gcnew ArrayType( 512,
-      ScanConverter::MAX_SAMPLES);
+    Buffer = gcnew ArrayType( ScanConverter::MAX_SAMPLES,
+      ScanConverter::MAX_SAMPLES );
     Handler = gcnew NewImageHandler( Buffer );
     HandlerDelegate = gcnew
       IntersonArray::Imaging::Capture::NewImageHandler( Handler,
         & NewImageHandler::HandleNewImage );
     Wrapped->NewImageTick += HandlerDelegate;
 
-    //RFBuffer = gcnew RFArrayType( ScanConverter::MAX_VECTORS,
-    RFBuffer = gcnew RFArrayType( 512,
+    RFBuffer = gcnew RFArrayType( ScanConverter::MAX_RFSAMPLES,
       ScanConverter::MAX_RFSAMPLES );
     RFHandler = gcnew NewRFImageHandler( RFBuffer );
     RFHandlerDelegate = gcnew

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,6 +23,7 @@
 set( _tests
   IntersonArrayCxxIntersonClassTest
   IntersonArrayCxxControlsHWControlsTest
+  IntersonArrayCxxImagingContainerTest
   IntersonArrayCxxImagingCaptureTest
   IntersonArrayCxxImagingScanConverterTest
   )

--- a/test/IntersonArrayCxxControlsHWControlsTest.cxx
+++ b/test/IntersonArrayCxxControlsHWControlsTest.cxx
@@ -31,9 +31,6 @@ int main( int argc, char * argv[] )
 
   HWControlsType hwControls;
 
-
-  std::cout << "ID_CA_OP_10MHz: " << hwControls.ID_CA_OP_10MHz << std::endl;
-
   std::cout << "ProbeID: " << static_cast< int >(
     hwControls.GetProbeID() ) << std::endl;
 

--- a/test/IntersonArrayCxxImagingContainerTest.cxx
+++ b/test/IntersonArrayCxxImagingContainerTest.cxx
@@ -1,0 +1,105 @@
+/*=========================================================================
+
+Library:   IntersonArrayArray
+
+Copyright Kitware Inc. 28 Corporate Drive,
+Clifton Park, NY, 12065, USA.
+
+All rights reserved.
+
+Licensed under the Apache License, Version 2.0 ( the "License" );
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=========================================================================*/
+#include "IntersonArrayCxxImagingContainer.h"
+#include "IntersonArrayCxxControlsHWControls.h"
+
+#include <cstdlib>
+#include <iostream>
+#include <vector>
+
+#include <Windows.h> // Sleep
+
+int main( int argc, char * argv[] )
+{
+  typedef IntersonArrayCxx::Controls::HWControls HWControlsType;
+  HWControlsType hwControls;
+
+  typedef IntersonArrayCxx::Imaging::Container ContainerType;
+  ContainerType container;
+
+  typedef HWControlsType::FoundProbesType FoundProbesType;
+  FoundProbesType foundProbes;
+  hwControls.FindAllProbes( foundProbes );
+  if( foundProbes.empty() )
+    {
+    std::cerr << "Could not find the probe." << std::endl;
+    return EXIT_FAILURE;
+    }
+
+  hwControls.FindMyProbe( 0 );
+  const unsigned int probeId = hwControls.GetProbeID();
+  std::cout << "ProbeID after FindMyProbe: " << probeId << std::endl;
+  if( probeId == 0 )
+    {
+    std::cerr << "Could not find the probe." << std::endl;
+    return EXIT_FAILURE;
+    }
+
+  const int depth = 50;
+  if( hwControls.ValidDepth( depth ) != depth )
+    {
+    std::cerr << "Did not request a valid depth" << std::endl;
+    return EXIT_SUCCESS;
+    }
+  const int width = 776;
+  const int height = 512; 
+
+  int steering = 0;
+  ContainerType::ScanConverterError converterError =
+    container.IdleInitScanConverter( depth, width, height, probeId,
+    steering, false, false, 0 );
+  if( converterError != ContainerType::SUCCESS )
+    {
+    std::cerr << "Error during idle scan converter initialization: "
+              << converterError << std::endl;
+    return EXIT_FAILURE;
+    }
+  converterError = container.HardInitScanConverter( depth, width,
+    height, steering );
+  if( converterError != ContainerType::SUCCESS )
+    {
+    std::cerr << "Error during hard scan converter initialization: "
+              << converterError << std::endl;
+    return EXIT_FAILURE;
+    }
+
+  container.AbortScan();
+  std::cout << "\nStarting BMode scanning..." << std::endl;
+  container.StartReadScan();
+  Sleep( 100 ); // "time to start"
+  hwControls.StartBmode();
+
+  std::cout << "\nScan is on: " << container.GetScanOn() << std::endl;
+  std::cout << "\nTrueDepth: " << container.GetTrueDepth() << std::endl;
+  std::cout << "\nHeightScan: " << container.GetHeightScan() << std::endl;
+  std::cout << "WidthScan:  " << container.GetWidthScan() << std::endl;
+  std::cout << "\nMmPerPixel: " << container.GetMmPerPixel() << std::endl;
+  std::cout << "\nZeroOfYScale: " << container.GetZeroOfYScale() << std::endl;
+
+  hwControls.StopAcquisition();
+  container.StopReadScan();
+  Sleep( 100 ); // "time to stop"
+  container.DisposeScan();
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
This merger of subclasses allows us to avoid having to pass
instances of subclasses to one another - which isn't possible
because it would require mixing managed and unmanaged code.

The IntersonArrayCxxImagingContainer class now supercedes
ImagingCapture
ImagingImageBuilding
ImagingScanConverter

Apps and tests have been updated accordingly.