### PR TITLE
ENH: Improve configuration export for build or install tree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,84 +20,89 @@
 # limitations under the License.
 #
 ##############################################################################
-cmake_minimum_required( VERSION 2.8 )
+
+cmake_minimum_required( VERSION 3.6 )
 
 project( IntersonArraySDKCxx )
 
-if( NOT CMAKE_RUNTIME_OUTPUT_DIRECTORY)
-  set( CMAKE_RUNTIME_OUTPUT_DIRECTORY ${IntersonArraySDKCxx_BINARY_DIR}/bin )
-endif()
-if( NOT CMAKE_LIBRARY_OUTPUT_DIRECTORY )
-  set( CMAKE_LIBRARY_OUTPUT_DIRECTORY ${IntersonArraySDKCxx_BINARY_DIR}/lib )
-endif()
-if(NOT CMAKE_ARCHIVE_OUTPUT_DIRECTORY)
-  set( CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${IntersonArraySDKCxx_BINARY_DIR}/lib )
-endif()
+# CMake modules
+include( CMakePackageConfigHelpers )
+include( CTest )
 
-set( CONF_INCLUDE_DIRS
-  ${PROJECT_SOURCE_DIR}/include
-  ${PROJECT_BINARY_DIR}/include )
-include_directories( ${CONF_INCLUDE_DIRS} )
+# Options
+option( BUILD_APPLICATIONS "Build applications" OFF )
 
-set( INSTALL_LIB_DIR lib )
-set( INSTALL_BIN_DIR bin )
-set( INSTALL_INCLUDE_DIR include )
-if( WIN32 AND NOT CYGWIN )
-  set( DEF_INSTALL_CMAKE_DIR CMake )
-else()
-  set( DEF_INSTALL_CMAKE_DIR lib/CMake/FooBar )
-endif()
-set( INSTALL_CMAKE_DIR ${DEF_INSTALL_CMAKE_DIR} )
-
-foreach( path LIB BIN INCLUDE CMAKE )
-  set( var INSTALL_${path}_DIR )
-  if( NOT IS_ABSOLUTE "${${var}}" )
-    set( ${var} "${CMAKE_INSTALL_PREFIX}/${${var}}" )
-  endif()
-endforeach()
-
-find_path( IntersonArraySDK_DIR NAMES Libraries/IntersonArray.dll
-  PATHS C:/IntersonArraySDK )
+# External dependencies
+find_path( IntersonArraySDK_DIR
+  NAMES Libraries/IntersonArray.dll
+  PATHS C:/IntersonArraySDK
+  )
 if( NOT IntersonArraySDK_DIR )
-  message( SEND_ERROR "Please specify the path to the IntersonArraySDK"
+  message( FATAL_ERROR "Please specify the path to the IntersonArraySDK"
     " in IntersonArraySDK_DIR" )
 endif()
 
-add_subdirectory( include )
-add_subdirectory( src )
+# Install relative directories
+set( INSTALL_LIB_DIR lib )
+set( INSTALL_BIN_DIR bin )
+set( INSTALL_INCLUDE_DIR include )
+set( INSTALL_CMAKE_DIR cmake )
 
-include( CTest )
-if( BUILD_TESTING )
-  enable_testing()
-  add_subdirectory( test )
+# Output directories
+if( NOT CMAKE_RUNTIME_OUTPUT_DIRECTORY )
+  set( CMAKE_RUNTIME_OUTPUT_DIRECTORY ${IntersonArraySDKCxx_BINARY_DIR}/${INSTALL_BIN_DIR} )
+endif()
+if( NOT CMAKE_LIBRARY_OUTPUT_DIRECTORY )
+  set( CMAKE_LIBRARY_OUTPUT_DIRECTORY ${IntersonArraySDKCxx_BINARY_DIR}/${INSTALL_LIB_DIR} )
+endif()
+if( NOT CMAKE_ARCHIVE_OUTPUT_DIRECTORY )
+  set( CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${IntersonArraySDKCxx_BINARY_DIR}/${INSTALL_LIB_DIR} )
 endif()
 
-option( BUILD_APPLICATIONS "Build applications" OFF )
+# Add subdirectories
+add_subdirectory( include )
+add_subdirectory( src )
+if( BUILD_TESTING )
+  add_subdirectory( test )
+endif()
 if( BUILD_APPLICATIONS )
   add_subdirectory( app )
 endif()
 
-export( TARGETS IntersonArrayCxx
-  FILE "${PROJECT_BINARY_DIR}/IntersonArraySDKCxxTargets.cmake" )
-export( PACKAGE IntersonArraySDKCxx )
-
-file( RELATIVE_PATH _relative_include_dir
-  "${INSTALL_CMAKE_DIR}" "${INSTALL_INCLUDE_DIR}" )
-
-configure_file( IntersonArraySDKCxxConfig.cmake.in
-  "${PROJECT_BINARY_DIR}/IntersonArraySDKCxxConfig.cmake" @ONLY )
-
-set( CONF_INCLUDE_DIRS
-  "\${IntersonArraySDKCxx_CMAKE_DIR}/${_relative_include_dir} ${CONF_INCLUDE_DIRS}" )
-configure_file( IntersonArraySDKCxxConfig.cmake.in
-  "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/IntersonArraySDKCxxConfig.cmake"
-  @ONLY )
-
-install( FILES
-  "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/IntersonArraySDKCxxConfig.cmake"
-  DESTINATION "${INSTALL_CMAKE_DIR}" COMPONENT Development
+# Configure 'IntersonArraySDKCxxConfig.cmake' for a build tree
+set(CONFIG_DIR_CONFIG ${PROJECT_BINARY_DIR})
+set(intersonArraySDKCxx_config ${PROJECT_BINARY_DIR}/IntersonArraySDKCxxConfig.cmake)
+configure_package_config_file(
+  IntersonArraySDKCxxConfig.cmake.in
+  ${intersonArraySDKCxx_config}
+  INSTALL_DESTINATION ${PROJECT_BINARY_DIR}
+  PATH_VARS CONFIG_DIR_CONFIG
+  NO_CHECK_REQUIRED_COMPONENTS_MACRO
   )
-install( EXPORT IntersonArraySDKCxxTargets DESTINATION
-  "${INSTALL_CMAKE_DIR}"
+  
+# Configure 'IntersonArraySDKCxxConfig.cmake' for an install tree
+set(CONFIG_DIR_CONFIG ${INSTALL_CMAKE_DIR})
+set( intersonArraySDKCxx_install_config ${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/IntersonArraySDKCxxConfig.cmake )
+configure_package_config_file(
+  IntersonArraySDKCxxConfig.cmake.in
+  ${intersonArraySDKCxx_install_config}
+  INSTALL_DESTINATION ${CMAKE_INSTALL_PREFIX}/${INSTALL_CMAKE_DIR}
+  PATH_VARS CONFIG_DIR_CONFIG
+  NO_CHECK_REQUIRED_COMPONENTS_MACRO
+  )
+install(
+  FILES ${intersonArraySDKCxx_install_config}
+  DESTINATION ${INSTALL_CMAKE_DIR} COMPONENT Development
+  )
+
+# Configure 'IntersonArraySDKCxxTargets.cmake'
+export( TARGETS IntersonArrayCxx
+  FILE ${PROJECT_BINARY_DIR}/IntersonArraySDKCxxTargets.cmake
+  )
+
+# Install 'IntersonArraySDKCxxTargets.cmake' and 'IntersonArraySDKCxxConfig.cmake'
+install( EXPORT IntersonArraySDKCxxTargets
+  FILE IntersonArraySDKCxxTargets.cmake
+  DESTINATION ${INSTALL_CMAKE_DIR}
   COMPONENT Development
   )

--- a/IntersonArraySDKCxxConfig.cmake.in
+++ b/IntersonArraySDKCxxConfig.cmake.in
@@ -24,35 +24,15 @@
 # Config file for the IntersonArraySDKCxx library wrapper.
 #
 # It defines the following variables:
-#   IntersonArraySDKCxx_INCLUDE_DIRS - include directories for
-#     IntersonArraySDKCxx
-#   IntersonArraySDKCxx_RUNTIME_LIBRARY_DIRS - directories that store the
-#     libraries needed for runtime execution
 #   IntersonArraySDKCxx_LIBRARIES    - libraries to link against
-#   IntersonArraySDK_DIR             - Path to the IntersonArraySDK used to
-#     build this library.
 
-get_filename_component( IntersonArraySDKCxx_CMAKE_DIR
- "${CMAKE_CURRENT_LIST_FILE}" PATH )
+@PACKAGE_INIT@
 
-set( IntersonArraySDKCxx_INCLUDE_DIRS "@CONF_INCLUDE_DIRS@" )
+set_and_check( IntersonArraySDKCxx_TARGETS "@PACKAGE_CONFIG_DIR_CONFIG@/IntersonArraySDKCxxTargets.cmake" )
 
-if( NOT TARGET IntersonArrayCxx AND NOT IntersonArraySDKCxx_BINARY_DIR )
-  include( "${IntersonArraySDKCxx_CMAKE_DIR}/IntersonArraySDKCxxTargets.cmake" )
+if( NOT IntersonArraySDKCxx_TARGETS_IMPORTED )
+  set( IntersonArraySDKCxx_TARGETS_IMPORTED 1 )
+  include( ${IntersonArraySDKCxx_TARGETS} )
 endif()
 
 set( IntersonArraySDKCxx_LIBRARIES IntersonArrayCxx )
-
-set( IntersonArrayCxx_RUNTIME_LIBRARY_DIRS )
-get_property( _configs TARGET IntersonArrayCxx PROPERTY
-  IMPORTED_CONFIGURATIONS )
-foreach( _config ${_configs} )
-  get_property( _libloc TARGET IntersonArrayCxx PROPERTY
-    IMPORTED_LOCATION_${_config} )
-  if( EXISTS "${_libloc}" )
-    get_filename_component( _libpath "${_libloc}" PATH )
-    list( APPEND IntersonArrayCxx_RUNTIME_LIBRARY_DIRS "${_libpath}" )
-  endif()
-endforeach()
-
-set( IntersonArraySDK_DIR "@IntersonArraySDK_DIR@" )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -73,13 +73,14 @@ install(
 if( BUILD_TESTING )
   add_custom_command( TARGET IntersonArrayCxx
     POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${IntersonArraySDK_DIR}/Libraries/IntersonArray.dll" "${PROJECT_BINARY_DIR}/bin"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${IntersonArraySDK_DIR}/Libraries/IntersonArray.dll" "${PROJECT_BINARY_DIR}/bin/$<CONFIG>"
     )
 endif()
 if( BUILD_APPLICATIONS )
   add_custom_command( TARGET IntersonArrayCxx
     POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${IntersonArraySDK_DIR}/Libraries/IntersonArray.dll" "${PROJECT_BINARY_DIR}/app/bin"
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${PROJECT_BINARY_DIR}/bin/IntersonArrayCxx.dll" "${PROJECT_BINARY_DIR}/app/bin"
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${PROJECT_BINARY_DIR}/app/bin/$<CONFIG>"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${IntersonArraySDK_DIR}/Libraries/IntersonArray.dll" "${PROJECT_BINARY_DIR}/app/bin/$<CONFIG>"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${PROJECT_BINARY_DIR}/bin/$<CONFIG>/IntersonArrayCxx.dll" "${PROJECT_BINARY_DIR}/app/bin/$<CONFIG>"
     )
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,6 +20,9 @@
 # limitations under the License.
 #
 ##############################################################################
+
+# XXX (Maeliss, Jc) Ideally, these flags should probably be associated with the
+#                   targets using target_compile_options command.
 if(CMAKE_CXX_FLAGS_DEBUG MATCHES "/RTC1")
   string(REPLACE "/RTC1" " " CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
 endif()
@@ -28,7 +31,6 @@ endif()
   #string(REPLACE "/EHsc" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 #endif()
 set( CMAKE_CXX_FLAGS "/clr /EHa /AI${IntersonArraySDK_DIR}/Libraries" )
-set( COMPILE_FLAGS "/clr /EHa /AI${IntersonArraySDK_DIR}/Libraries" )
 
 set( IntersonArrayCxx_SRCS
   IntersonArrayCxxControlsHWControls.cxx
@@ -36,27 +38,39 @@ set( IntersonArrayCxx_SRCS
   IntersonArrayCxxIntersonClass.cxx
   )
 
-include( GenerateExportHeader )
 add_library( IntersonArrayCxx SHARED
   ${IntersonArrayCxx_SRCS} )
 
+target_include_directories( IntersonArrayCxx PUBLIC
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+  )
+
+# Generate and install export header
+include( GenerateExportHeader )
+set(export_header ${PROJECT_BINARY_DIR}/include/IntersonArrayCxx_Export.h)
 generate_export_header( IntersonArrayCxx
   BASE_NAME IntersonArrayCxx
   EXPORT_MACRO_NAME IntersonArrayCxx_EXPORT
-  EXPORT_FILE_NAME ${PROJECT_BINARY_DIR}/include/IntersonArrayCxx_Export.h
+  EXPORT_FILE_NAME ${export_header}
   )
-#set_target_properties( IntersonArrayCxx PROPERTIES
-  #CMAKE_CXX_FLAGS "/clr /EHa /AI${IntersonArraySDK_DIR}/Libraries"
-  #)
-  # COMPILE_FLAGS "/clr /EHa /AI${IntersonArraySDK_DIR}/Libraries"
+install(
+  FILES ${export_header}
+  DESTINATION include COMPONENT Development
+  )
 
-install( TARGETS IntersonArrayCxx
+# Install library
+install(
+  TARGETS IntersonArrayCxx
   EXPORT IntersonArraySDKCxxTargets
   RUNTIME DESTINATION "${INSTALL_BIN_DIR}" COMPONENT Runtime
   LIBRARY DESTINATION "${INSTALL_LIB_DIR}" COMPONENT Development
+  ARCHIVE DESTINATION "${INSTALL_LIB_DIR}" COMPONENT Development
   )
+
+# Copy "IntersonArray.dll" and "IntersonArrayCxx.dll" to allow tests and applications to be executed from the build directory
 if( BUILD_TESTING )
-  # For running tests
   add_custom_command( TARGET IntersonArrayCxx
     POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_if_different "${IntersonArraySDK_DIR}/Libraries/IntersonArray.dll" "${PROJECT_BINARY_DIR}/bin"
@@ -66,9 +80,6 @@ if( BUILD_APPLICATIONS )
   add_custom_command( TARGET IntersonArrayCxx
     POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_if_different "${IntersonArraySDK_DIR}/Libraries/IntersonArray.dll" "${PROJECT_BINARY_DIR}/app/bin"
-    )
-  add_custom_command( TARGET IntersonArrayCxx
-    POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_if_different "${PROJECT_BINARY_DIR}/bin/IntersonArrayCxx.dll" "${PROJECT_BINARY_DIR}/app/bin"
     )
 endif()


### PR DESCRIPTION
This commit updates the buildsystem to allow other projects to include
"IntersonArraySDKCxx" using either its build or install tree.

This means that configuring a project Foo with

  -DIntersonArraySDKCxx_DIR:PATH:/path/to/IntersonArraySDKCxx-build-Release

or

  -DIntersonArraySDKCxx_DIR:PATH:/path/to/IntersonArraySDKCxx-install

will allow

  find_package(IntersonArraySDKCxx REQUIRED)

to work as expected within Foo CMakeLists.txt.