### PR TITLE
Fix Buffer Size

### DIFF
--- a/app/AcquireIntersonArrayBMode.cxx
+++ b/app/AcquireIntersonArrayBMode.cxx
@@ -126,7 +126,7 @@ int main( int argc, char * argv[] )
   container.SetRFData( false );
 
   const int height = hwControls.GetLinesPerArray();
-  const int width = 512; //container.MAX_SAMPLES;
+  const int width = container.MAX_SAMPLES;
   if( hwControls.ValidDepth( depth ) == depth )
     {
     ContainerType::ScanConverterError converterErrorIdle =

--- a/src/IntersonArrayCxxImagingContainer.cxx
+++ b/src/IntersonArrayCxxImagingContainer.cxx
@@ -84,12 +84,6 @@ public:
     }
   }
 
-  void SetImageSize( int width, int height )
-  {
-     //bufferWidth = width;
-     //bufferHeight = height;
-  }
-
   void SetNewRFImageCallback( NewRFImageCallbackType callback,
     void *clientData )
   {
@@ -124,8 +118,6 @@ public:
       Container::NBOFLINES ] ),
     ManagedBuffer( managedBuffer )
   {
-     std::cout << "Conatiner NBOFLINES: " << Container::NBOFLINES << std::endl;
-
   }
 
   ~NewImageHandler()
@@ -151,11 +143,6 @@ public:
     }
   }
 
-  void SetImageSize( int width, int height )
-  {
-    // bufferWidth = width;
-    // bufferHeight = height;
-  }
 
   void SetNewImageCallback( NewImageCallbackType callback,
     void *clientData )
@@ -344,16 +331,12 @@ public:
     void *clientData = 0 )
   {
     this->Handler->SetNewImageCallback( callback, clientData );
-    
-    //this->Handler->SetImageSize( this->GetWidthScan(),
-    //  this->GetHeightScan() );
   }
 
   void SetNewRFImageCallback( NewRFImageCallbackType callback,
     void *clientData = 0 )
   {
     this->RFHandler->SetNewRFImageCallback( callback, clientData );
-    this->RFHandler->SetImageSize(Container::MAX_RFSAMPLES, Container::NBOFLINES);
   }
   void SetHWControls(IntersonArrayCxx::Controls::HWControls * controls)
   {

--- a/src/IntersonArrayCxxImagingContainer.cxx
+++ b/src/IntersonArrayCxxImagingContainer.cxx
@@ -54,7 +54,7 @@ public:
     NewRFImageCallback( NULL ),
     NewRFImageCallbackClientData( NULL ),
     bufferWidth( Container::MAX_RFSAMPLES ),
-    bufferHeight( Container::MAX_RFSAMPLES ),
+    bufferHeight( Container::NBOFLINES ),
     NativeRFBuffer(new RFImagePixelType[Container::MAX_RFSAMPLES
       * Container::NBOFLINES] ),
     ManagedRFBuffer( managedRFBuffer )
@@ -86,8 +86,8 @@ public:
 
   void SetImageSize( int width, int height )
   {
-     bufferWidth = width;
-     bufferHeight = height;
+     //bufferWidth = width;
+     //bufferHeight = height;
   }
 
   void SetNewRFImageCallback( NewRFImageCallbackType callback,
@@ -119,11 +119,13 @@ public:
     NewImageCallback( NULL ),
     NewImageCallbackClientData( NULL ),
     bufferWidth( Container::MAX_SAMPLES ),
-    bufferHeight( Container::MAX_SAMPLES ),
+    bufferHeight( Container::NBOFLINES ),
     NativeBuffer( new PixelType[Container::MAX_SAMPLES *
-      Container::MAX_SAMPLES] ),
+      Container::NBOFLINES ] ),
     ManagedBuffer( managedBuffer )
   {
+     std::cout << "Conatiner NBOFLINES: " << Container::NBOFLINES << std::endl;
+
   }
 
   ~NewImageHandler()
@@ -151,8 +153,8 @@ public:
 
   void SetImageSize( int width, int height )
   {
-     bufferWidth = width;
-     bufferHeight = height;
+    // bufferWidth = width;
+    // bufferHeight = height;
   }
 
   void SetNewImageCallback( NewImageCallbackType callback,
@@ -188,8 +190,7 @@ public:
     WrappedImageBuilding = gcnew IntersonArray::Imaging::ImageBuilding();
     WrappedCapture = gcnew IntersonArray::Imaging::Capture();
 
-    Buffer = gcnew ArrayType( Container::MAX_SAMPLES,
-      Container::MAX_SAMPLES);
+    Buffer = gcnew ArrayType( Container::NBOFLINES, Container::MAX_SAMPLES );
     Handler = gcnew NewImageHandler( Buffer );
     HandlerDelegate = gcnew
       IntersonArray::Imaging::Capture::NewImageHandler( Handler,
@@ -257,6 +258,7 @@ public:
   Container::ScanConverterError HardInitScanConverter( int depth,
     int widthScan, int heightScan, int steering )
   {
+    
     return static_cast< Container::ScanConverterError >(
       WrappedScanConverter->HardInitScanConverter( depth, widthScan,
         heightScan, steering, WrappedCapture.get(),
@@ -342,8 +344,9 @@ public:
     void *clientData = 0 )
   {
     this->Handler->SetNewImageCallback( callback, clientData );
-    this->Handler->SetImageSize( this->GetWidthScan(),
-      this->GetHeightScan() );
+    
+    //this->Handler->SetImageSize( this->GetWidthScan(),
+    //  this->GetHeightScan() );
   }
 
   void SetNewRFImageCallback( NewRFImageCallbackType callback,


### PR DESCRIPTION
The buffer size in the Bmode image was to large. The buffer size is unaffacted
by scanWidth and scanHeight in the ScanConverter and appers to have a fixed size
of NBOLINES x MAX_SAMPLES.

Now teh BMode images is received at full depth and the image size does not ahve to
be set to MAX_SMAPLES/2.