### PR TITLE
Fix Managed Code

### DIFF
--- a/src/IntersonArrayCxxControlsHWControls.cxx
+++ b/src/IntersonArrayCxxControlsHWControls.cxx
@@ -21,17 +21,17 @@ limitations under the License.
 
 =========================================================================*/
 // C++
-#pragma unmanaged
 #include "IntersonArrayCxxControlsHWControls.h"
 
 // C#
-#pragma managed
 
 #include <vcclr.h>
 #include <msclr/marshal_cppstd.h>
 
 // Add library from SDK
 #using "IntersonArray.dll"
+
+#pragma managed
 
 namespace IntersonArrayCxx
 {

--- a/src/IntersonArrayCxxImagingContainer.cxx
+++ b/src/IntersonArrayCxxImagingContainer.cxx
@@ -20,16 +20,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 =========================================================================*/
-#pragma unmanaged
 #include "IntersonArrayCxxImagingContainer.h"
 #include <iostream>
-#pragma managed
 
 #include <vcclr.h>
 #include <msclr/marshal_cppstd.h>
 #include <msclr/auto_gcroot.h>
 
 #using "IntersonArray.dll"
+
+#pragma managed
 
 namespace IntersonArrayCxx
 {

--- a/src/IntersonArrayCxxIntersonClass.cxx
+++ b/src/IntersonArrayCxxIntersonClass.cxx
@@ -21,17 +21,17 @@ limitations under the License.
 
 =========================================================================*/
 // C++
-#pragma unmanaged
 #include "IntersonArrayCxxIntersonClass.h"
 
 // C#
-#pragma managed
 
 #include <vcclr.h>
 #include <msclr/marshal_cppstd.h>
 
 // Add library from SDK
 #using "IntersonArray.dll"
+
+#pragma managed
 
 namespace IntersonArrayCxx
 {


### PR DESCRIPTION
Managed code #pragma caused compile errors with Visual Studio 15 2017 due to being used before includes