### PR TITLE
ENH: Now supports ninja build

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -74,6 +74,7 @@ if( BUILD_TESTING )
   add_custom_command( TARGET IntersonArrayCxx
     POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_if_different "${IntersonArraySDK_DIR}/Libraries/IntersonArray.dll" "${PROJECT_BINARY_DIR}/bin/$<CONFIG>"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${IntersonArraySDK_DIR}/Libraries/IntersonArray.dll" "${PROJECT_BINARY_DIR}/bin"
     )
 endif()
 if( BUILD_APPLICATIONS )
@@ -81,6 +82,8 @@ if( BUILD_APPLICATIONS )
     POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E make_directory "${PROJECT_BINARY_DIR}/app/bin/$<CONFIG>"
     COMMAND ${CMAKE_COMMAND} -E copy_if_different "${IntersonArraySDK_DIR}/Libraries/IntersonArray.dll" "${PROJECT_BINARY_DIR}/app/bin/$<CONFIG>"
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${PROJECT_BINARY_DIR}/bin/$<CONFIG>/IntersonArrayCxx.dll" "${PROJECT_BINARY_DIR}/app/bin/$<CONFIG>"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:IntersonArrayCxx>" "${PROJECT_BINARY_DIR}/app/bin/$<CONFIG>"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${IntersonArraySDK_DIR}/Libraries/IntersonArray.dll" "${PROJECT_BINARY_DIR}/app/bin"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:IntersonArrayCxx>" "${PROJECT_BINARY_DIR}/app/bin"
     )
 endif()

--- a/src/IntersonArrayCxxImagingContainer.cxx
+++ b/src/IntersonArrayCxxImagingContainer.cxx
@@ -54,7 +54,7 @@ public:
     NewRFImageCallback( NULL ),
     NewRFImageCallbackClientData( NULL ),
     bufferWidth( Container::MAX_RFSAMPLES ),
-    bufferHeight( Container::MAX_RFSAMPLES ),
+    bufferHeight( Container::NBOFLINES ),
     NativeRFBuffer(new RFImagePixelType[Container::MAX_RFSAMPLES
       * Container::NBOFLINES] ),
     ManagedRFBuffer( managedRFBuffer )
@@ -191,13 +191,16 @@ public:
     Buffer = gcnew ArrayType( Container::MAX_SAMPLES,
       Container::MAX_SAMPLES);
     Handler = gcnew NewImageHandler( Buffer );
+    Handler->SetImageSize( Container::MAX_SAMPLES, Container::MAX_SAMPLES );
     HandlerDelegate = gcnew
       IntersonArray::Imaging::Capture::NewImageHandler( Handler,
         & NewImageHandler::HandleNewImage );
     WrappedCapture->NewImageTick += HandlerDelegate;
 
-    RFBuffer = gcnew RFArrayType(Container::NBOFLINES , Container::MAX_RFSAMPLES);
+    RFBuffer = gcnew RFArrayType( Container::NBOFLINES,
+      Container::MAX_RFSAMPLES );
     RFHandler = gcnew NewRFImageHandler( RFBuffer );
+    RFHandler->SetImageSize( Container::MAX_RFSAMPLES, Container::NBOFLINES );
     RFHandlerDelegate = gcnew
       IntersonArray::Imaging::Capture::NewImageHandler( RFHandler,
         & NewRFImageHandler::HandleNewRFImage );


### PR DESCRIPTION
Ninja does not write libs/exec to $<CONFIG> (e.g., Release or
Debug) subdirs in the bin or libs directories.  So, these
changes updates the copy commands to use proper source and
target files and directories for ninja and visual studios.