### PR TITLE
ENH: Update for Interson SDK version 2.21

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ if( NOT IntersonArraySDK_DIR )
   message( FATAL_ERROR "Please specify the path to the IntersonArraySDK"
     " in IntersonArraySDK_DIR" )
 endif()
-set( IntersonArraySDK_LIBRARY "${IntersonArraySDK_DIR}/Libraries/IntersonArray.dll" )
+set( IntersonArraySDK_LIBRARY "${IntersonArraySDK_DIR}/IntersonArray.dll" )
 if( NOT EXISTS ${IntersonArraySDK_LIBRARY} )
   message( FATAL_ERROR "Interson library is missing [${IntersonArraySDK_LIBRARY}]" )
 endif()

--- a/openigtlink/CMakeLists.txt
+++ b/openigtlink/CMakeLists.txt
@@ -26,6 +26,8 @@ include( ${SlicerExecutionModel_USE_FILE} )
 find_package(OpenIGTLink REQUIRED)
 include(${OpenIGTLink_USE_FILE})
 
+find_package( ITK REQUIRED )
+include( ${ITK_USE_FILE} )
 
 SEMMacroBuildCLI(
   NAME IntersonArrayServerRF
@@ -35,4 +37,13 @@ SEMMacroBuildCLI(
   INCLUDE_DIRECTORIES ${PROJECT_SOURCE_DIR}/include
                       ${PROJECT_BINARY_DIR}/include
   )
+  
+SEMMacroBuildCLI(
+  NAME IntersonArrayServerBMode
+  TARGET_LIBRARIES ${ITK_LIBRARIES}
+                   IntersonArrayCxx
+                   OpenIGTLink
+  INCLUDE_DIRECTORIES ${PROJECT_SOURCE_DIR}/include
+                      ${PROJECT_BINARY_DIR}/include
+)
 

--- a/openigtlink/IntersonArrayServerBMode.cxx
+++ b/openigtlink/IntersonArrayServerBMode.cxx
@@ -1,0 +1,309 @@
+/*=========================================================================
+
+Library:   IntersonArray
+
+Copyright Kitware Inc. 28 Corporate Drive,
+Clifton Park, NY, 12065, USA.
+
+All rights reserved.
+
+Licensed under the Apache License, Version 2.0 ( the "License" );
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=========================================================================*/
+#include <Windows.h> // Sleep
+
+#include "itkImageFileWriter.h"
+
+#include "IntersonArrayCxxControlsHWControls.h"
+#include "IntersonArrayCxxImagingContainer.h"
+
+#include "igtlImageMessage.h"
+#include "igtlServerSocket.h"
+
+#include "IntersonArrayServerBModeCLP.h"
+
+bool running;
+
+typedef IntersonArrayCxx::Imaging::Container ContainerType;
+
+const unsigned int Dimension = 3;
+typedef ContainerType::PixelType           PixelType;
+typedef itk::Image< PixelType, Dimension > ImageType;
+
+BOOL WINAPI consoleHandler(DWORD signal) {
+
+    if (signal == CTRL_C_EVENT)
+    {
+        running = false;
+    }
+
+    return TRUE;
+}
+
+struct CallbackClientData
+{
+    itk::SizeValueType FrameIndex;
+    igtl::Socket* socket;
+    igtl::ImageMessage* imgMsg;
+    igtl::TimeStamp* ts;
+    int width;
+    int height;
+};
+
+
+void __stdcall pasteIntoImage(PixelType* buffer, void* clientData)
+{
+    CallbackClientData* callbackClientData =
+        static_cast<CallbackClientData*>(clientData);
+
+    std::cout << "Acquired frame: " << callbackClientData->FrameIndex
+        << std::endl;
+    ++(callbackClientData->FrameIndex);
+
+    // sending to openigtlink
+    igtl::ImageMessage* message = callbackClientData->imgMsg;
+    igtl::Socket* socket = callbackClientData->socket;
+    igtl::TimeStamp* ts = callbackClientData->ts;
+
+    int framePixels = callbackClientData->width * callbackClientData->height;
+
+    message->SetMessageID(callbackClientData->FrameIndex);
+    ts->GetTime();
+    igtlUint32 sec;
+    igtlUint32 nsec;
+    ts->GetTimeStamp(&sec, &nsec);
+    message->SetTimeStamp(sec, nsec);
+
+    std::memcpy(message->GetScalarPointer(), buffer, framePixels * sizeof(PixelType));
+
+    if (!socket)
+    {
+        return;
+    }
+
+    message->Pack();
+    socket->Send(message->GetPackPointer(), message->GetPackSize());
+}
+
+
+int main(int argc, char* argv[])
+{
+    PARSE_ARGS;
+
+    typedef IntersonArrayCxx::Controls::HWControls HWControlsType;
+    HWControlsType hwControls;
+
+    const int steering = 0;
+    typedef HWControlsType::FoundProbesType FoundProbesType;
+    FoundProbesType foundProbes;
+    hwControls.FindAllProbes(foundProbes);
+    if (foundProbes.empty())
+    {
+        std::cerr << "Could not find the probe." << std::endl;
+        return EXIT_FAILURE;
+    }
+    hwControls.FindMyProbe(0);
+    const unsigned int probeId = hwControls.GetProbeID();
+    if (probeId == 0)
+    {
+        std::cerr << "Could not find the probe." << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    HWControlsType::FrequenciesType frequencies;
+    hwControls.GetFrequency(frequencies);
+
+    HWControlsType::FocusType focuses;
+    hwControls.GetFocus(focuses);
+
+    if (!hwControls.SetFrequencyAndFocus(frequencyIndex, focusIndex,
+        steering))
+    {
+        std::cerr << "Could not set the frequency." << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    if (!hwControls.SendHighVoltage(highVoltage, highVoltage))
+    {
+        std::cerr << "Could not set the high voltage." << std::endl;
+        return EXIT_FAILURE;
+    }
+    if (!hwControls.EnableHighVoltage())
+    {
+        std::cerr << "Could not enable high voltage." << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    if (!hwControls.SendDynamic(gain))
+    {
+        std::cerr << "Could not set dynamic gain." << std::endl;
+    }
+
+    hwControls.DisableHardButton();
+
+    ContainerType container;
+    container.SetRFData(false);
+
+    const int height = hwControls.GetLinesPerArray();
+    const int width = container.MAX_SAMPLES;
+    const int depth = 100;
+    const int depthCfm = 50;
+    if (hwControls.ValidDepth(depth) == depth)
+    {
+        ContainerType::ScanConverterError converterErrorIdle =
+            container.IdleInitScanConverter(depth, width, height, probeId,
+                steering, depthCfm, false, false, 0, false);
+        ContainerType::ScanConverterError converterError =
+            container.HardInitScanConverter(depth, width, height, steering,
+                depthCfm);
+        if (converterError != ContainerType::SUCCESS)
+        {
+            std::cerr << "Error during hard scan converter initialization: "
+                << converterError << std::endl;
+            return EXIT_FAILURE;
+        }
+    }
+    else
+    {
+        std::cerr << "Invalid requested depth for probe." << std::endl;
+    }
+
+    const int scanWidth = container.GetWidthScan();
+    const int scanHeight = container.GetHeightScan();
+    std::cout << "Width = " << width << std::endl;
+    std::cout << "Height = " << height << std::endl;
+    std::cout << "ScanWidth = " << scanWidth << std::endl;
+    std::cout << "ScanHeight = " << scanHeight << std::endl;
+    std::cout << "MM per Pixel = " << container.GetMmPerPixel() << std::endl;
+    std::cout << "Depth: " << depth << "mm" << std::endl;
+    std::cout << std::endl;
+
+    int imageSize[3];
+    imageSize[0] = width;
+    imageSize[1] = height;
+    imageSize[2] = 1;
+    
+    float imageSpacing[3];
+    imageSpacing[0] = container.GetMmPerPixel() / 10.;
+    imageSpacing[1] = 38.0 / (height - 1);
+    const short frameRate = hwControls.GetProbeFrameRate();
+    imageSpacing[2] = 1.0 / frameRate;
+    
+    //------------------------------------------------------------
+      // Create a new IMAGE type message
+    igtl::ImageMessage::Pointer imgMsg = igtl::ImageMessage::New();
+    imgMsg->SetDimensions(imageSize);
+    imgMsg->SetSpacing(imageSpacing);
+    imgMsg->SetScalarType(igtl::ImageMessage::TYPE_UINT8);
+    imgMsg->SetDeviceName("IntersonBMode");
+
+    int   svsize[] = { imageSize[0], imageSize[1], 1 };       // sub-volume size
+    int   svoffset[] = { 0, 0, 0 };
+
+    imgMsg->SetSubVolume(svsize, svoffset);
+    imgMsg->SetHeaderVersion(IGTL_HEADER_VERSION_2);
+    IANA_ENCODING_TYPE codingScheme = IANA_TYPE_US_ASCII;
+
+    //Add meta data here
+    imgMsg->SetMetaDataElement("Frequency (MHz)", codingScheme, std::to_string(frequencies[frequencyIndex]));
+    imgMsg->SetMetaDataElement("Focus (mm)", codingScheme, std::to_string(focuses[focusIndex]));
+    imgMsg->SetMetaDataElement("High voltage", codingScheme, std::to_string(highVoltage));
+    imgMsg->SetMetaDataElement("FPS", codingScheme, std::to_string(frameRate));
+    imgMsg->SetMetaDataElement("Steering", codingScheme, std::to_string(steering));
+    imgMsg->SetMetaDataElement("Image Type", codingScheme, "RF");
+    imgMsg->SetMetaDataElement("Timestamp seconds", codingScheme, "0");
+    imgMsg->SetMetaDataElement("Timestamp nseconds", codingScheme, "0");
+
+    imgMsg->AllocateScalars();
+    imgMsg->SetEndian(igtl::ImageMessage::ENDIAN_LITTLE);
+    imgMsg->SetCoordinateSystem(igtl::ImageMessage::COORDINATE_LPS); // LPS
+    igtl::Matrix4x4 matrix;
+    matrix[0][0] = 0.0;  matrix[1][0] = -1.0;  matrix[2][0] = 0.0; matrix[3][0] = 0.0;
+    matrix[0][1] = 1.0;  matrix[1][1] = 0.0;  matrix[2][1] = 0.0; matrix[3][1] = 0.0;
+    matrix[0][2] = 0.0;  matrix[1][2] = 0.0;  matrix[2][2] = 1.0; matrix[3][2] = 0.0;
+    matrix[0][3] = 0.0;  matrix[1][3] = 0.0;  matrix[2][3] = 0.0; matrix[3][3] = 1.0;
+    /*igtl::Matrix4x4 matrix;
+    matrix[0][0] = 0.0;  matrix[0][1] = 1.0;  matrix[0][2] = 0.0; matrix[0][3] = 0.0;
+    matrix[1][2] = -1.0;  matrix[1][2] = 0.0;  matrix[1][2] = 0.0; matrix[1][3] = 0.0;
+    matrix[2][2] = 0.0;  matrix[2][2] = 0.0;  matrix[2][2] = 1.0; matrix[2][3] = 0.0;
+    matrix[3][2] = 0.0;  matrix[3][2] = 0.0;  matrix[3][2] = 0.0; matrix[3][3] = 1.0;*/
+
+
+//    matrix[0][0] = -1.0;  matrix[0][1] = 0.0;  matrix[0][2] = 0.0; matrix[0][3] = 0.0;
+//    matrix[1][2] = 0.0;  matrix[1][2] = 1.0;  matrix[1][2] = 0.0; matrix[1][3] = 0.0;
+//    matrix[2][2] = 0.0;  matrix[2][2] = 0.0;  matrix[2][2] = 1.0; matrix[2][3] = 0.0;
+//    matrix[3][2] = 0.0;  matrix[3][2] = 0.0;  matrix[3][2] = 0.0; matrix[3][3] = 1.0;
+    imgMsg->SetMatrix(matrix);
+    igtl::TimeStamp::Pointer ts = igtl::TimeStamp::New();
+
+    CallbackClientData clientData;
+    clientData.ts = ts.GetPointer();
+    clientData.imgMsg = imgMsg.GetPointer();
+    clientData.FrameIndex = 0;
+    clientData.width = imageSize[0];
+    clientData.height = imageSize[1];
+
+    //socket setup
+    igtl::ServerSocket::Pointer serverSocket;
+    serverSocket = igtl::ServerSocket::New();
+    int r = serverSocket->CreateServer(port);
+
+    if (r < 0)
+    {
+        std::cerr << "Cannot create a server socket." << std::endl;
+        exit(0);
+    }
+    std::cerr << "Created Server socket." << std::endl;
+    igtl::Socket::Pointer socket;
+    clientData.socket = socket;
+
+    container.SetNewImageCallback(&pasteIntoImage, &clientData);
+    container.StartReadScan();
+    Sleep(100); // "time to start"
+    if (!hwControls.StartBmode())
+    {
+        std::cerr << "Could not start B-mode collection." << std::endl;
+        return EXIT_FAILURE;
+    };
+
+    if (!SetConsoleCtrlHandler(consoleHandler, TRUE))
+    {
+        std::cout << "Could not set control handler" << std::endl;
+        return 1;
+    }
+    running = true;
+    std::cout << "Server is running, use Ctrl-C to stop" << std::endl;
+    while (running)
+    {
+        //------------------------------------------------------------
+        // Waiting for Connection
+        socket = serverSocket->WaitForConnection(1000);
+        clientData.socket = socket.GetPointer();
+        if (socket.IsNotNull()) // if client connected
+        {
+            Sleep(10000);  //chill for a bit
+        }
+
+    }
+
+    std::cout << "Shutting down" << std::endl;
+    hwControls.StopAcquisition();
+    container.StopReadScan();
+    if (socket)
+    {
+        socket->CloseSocket();
+    }
+
+    Sleep(100); // "time to stop"
+    return EXIT_SUCCESS;
+}

--- a/openigtlink/IntersonArrayServerBMode.xml
+++ b/openigtlink/IntersonArrayServerBMode.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <executable>
   <category>Ultrasound</category>
-  <title>Interson RF OpenIGTLink Server</title>
-  <description>Broadcast RF images over OpenIGTLink.</description>
+  <title>Acquire Interson B Mode</title>
+  <description>Acquire multiple B-Mode frames with the Interson USB probe.</description>
   <version>0.1.0</version>
   <license>Apache 2.0</license>
-  <contributor>Sam Horvath (Kitware), Matt McCormick (Kitware)</contributor>
-  <acknowledgements>This work is funded in part by a grant with InnerOptic/Kitware</acknowledgements>
+  <contributor>Brad T. Moore (Kitware)</contributor>
+  <acknowledgements>This effort was sponsored by the U.S. Government under Other Transactions Number W81XWH-15-9-0001/W81XWH-19-9-0015 (MTEC 19-08-MuLTI-0079).</acknowledgements>
   <parameters>
     <integer>
       <name>port</name>
@@ -15,6 +15,14 @@
       <longflag>port</longflag>
       <flag>p</flag>
       <default>18944</default>
+    </integer>
+    <integer>
+      <name>frames</name>
+      <label>Frames</label>
+      <description>Frames to collect.</description>
+      <longflag>frames</longflag>
+      <flag>n</flag>
+      <default>1</default>
     </integer>
     <integer>
       <name>frequencyIndex</name>
@@ -42,12 +50,15 @@
       <minimum>0</minimum>
       <maximum>100</maximum>
     </integer>
-    <double>
-      <name>sos</name>
-      <label>Speed of sound</label>
-      <description> Assumed speed of sound in the crossed medium in mm/ms.</description>
-      <longflag>sos</longflag>
-      <default>1540</default>
-    </double>
+    <integer>
+      <name>gain</name>
+      <label>Dynamic Gain</label>
+      <description>Dynamic gain [dB].</description>
+      <longflag>gain</longflag>
+      <flag>g</flag>
+      <default>100</default>
+      <minimum>0</minimum>
+      <maximum>255</maximum>
+    </integer>
   </parameters>
 </executable>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,7 +30,7 @@ endif()
 #if(CMAKE_CXX_FLAGS MATCHES "/EHsc")
   #string(REPLACE "/EHsc" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 #endif()
-set( CMAKE_CXX_FLAGS "/clr /EHa /AI${IntersonArraySDK_DIR}/Libraries" )
+set( CMAKE_CXX_FLAGS "/clr /EHa /AI\"${IntersonArraySDK_DIR}\"" )
 
 set( IntersonArrayCxx_SRCS
   IntersonArrayCxxControlsHWControls.cxx
@@ -81,8 +81,8 @@ install(
 if( BUILD_TESTING )
   add_custom_command( TARGET IntersonArrayCxx
     POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${IntersonArraySDK_DIR}/Libraries/IntersonArray.dll" "${PROJECT_BINARY_DIR}/bin/$<CONFIG>"
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${IntersonArraySDK_DIR}/Libraries/IntersonArray.dll" "${PROJECT_BINARY_DIR}/bin"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${IntersonArraySDK_DIR}/IntersonArray.dll" "${PROJECT_BINARY_DIR}/bin/$<CONFIG>"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${IntersonArraySDK_DIR}/IntersonArray.dll" "${PROJECT_BINARY_DIR}/bin"
     COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:IntersonArrayCxx>" "${PROJECT_BINARY_DIR}/bin/$<CONFIG>"
     COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:IntersonArrayCxx>" "${PROJECT_BINARY_DIR}/bin/"
     )
@@ -91,9 +91,9 @@ if( BUILD_APPLICATIONS )
   add_custom_command( TARGET IntersonArrayCxx
     POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E make_directory "${PROJECT_BINARY_DIR}/app/bin/$<CONFIG>"
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${IntersonArraySDK_DIR}/Libraries/IntersonArray.dll" "${PROJECT_BINARY_DIR}/app/bin/$<CONFIG>"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${IntersonArraySDK_DIR}/IntersonArray.dll" "${PROJECT_BINARY_DIR}/app/bin/$<CONFIG>"
     COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:IntersonArrayCxx>" "${PROJECT_BINARY_DIR}/app/bin/$<CONFIG>"
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${IntersonArraySDK_DIR}/Libraries/IntersonArray.dll" "${PROJECT_BINARY_DIR}/app/bin"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${IntersonArraySDK_DIR}/IntersonArray.dll" "${PROJECT_BINARY_DIR}/app/bin"
     COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:IntersonArrayCxx>" "${PROJECT_BINARY_DIR}/app/bin"
     )
 endif()
@@ -102,9 +102,9 @@ if( BUILD_SERVERS )
   add_custom_command( TARGET IntersonArrayCxx
     POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E make_directory "${PROJECT_BINARY_DIR}/openigtlink/bin/$<CONFIG>"
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${IntersonArraySDK_DIR}/Libraries/IntersonArray.dll" "${PROJECT_BINARY_DIR}/openigtlink/bin/$<CONFIG>"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${IntersonArraySDK_DIR}/IntersonArray.dll" "${PROJECT_BINARY_DIR}/openigtlink/bin/$<CONFIG>"
     COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:IntersonArrayCxx>" "${PROJECT_BINARY_DIR}/openigtlink/bin/$<CONFIG>"
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${IntersonArraySDK_DIR}/Libraries/IntersonArray.dll" "${PROJECT_BINARY_DIR}/openigtlink/bin"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${IntersonArraySDK_DIR}/IntersonArray.dll" "${PROJECT_BINARY_DIR}/openigtlink/bin"
     COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:IntersonArrayCxx>" "${PROJECT_BINARY_DIR}/openigtlink/bin"
     )
 endif()

--- a/src/IntersonArrayCxxControlsHWControls.cxx
+++ b/src/IntersonArrayCxxControlsHWControls.cxx
@@ -92,14 +92,14 @@ public:
 
     HardButtonHandler = gcnew NewHardButtonHandler();
     HardButtonHandlerDelegate = gcnew
-      IntersonArray::Controls::HWControls::HWButtonHandler(
+      IntersonArray::Controls::HWControls::HWButtonHandlerReleased(
         HardButtonHandler, &NewHardButtonHandler::HandleNewHardButton );
-    Wrapped->HWButtonTick += HardButtonHandlerDelegate;
+    Wrapped->HWButtonTickReleased += HardButtonHandlerDelegate;
   }
 
   ~HWControlsImpl()
   {
-  Wrapped->HWButtonTick -= HardButtonHandlerDelegate;
+  Wrapped->HWButtonTickReleased -= HardButtonHandlerDelegate;
   }
 
   // Compound Angle Functions
@@ -351,7 +351,7 @@ private:
 
   gcroot< IntersonArray::Controls::HWControls ^ > Wrapped;
   gcroot< NewHardButtonHandler ^ >                HardButtonHandler;
-  gcroot< IntersonArray::Controls::HWControls::HWButtonHandler ^ >
+  gcroot< IntersonArray::Controls::HWControls::HWButtonHandlerReleased ^ >
                                                   HardButtonHandlerDelegate;
 
 };


### PR DESCRIPTION
I modified the value of IntersonArraySDK_DIR to point to the actual folder containing the DLLs, not a parent folder a couple of steps up.  The folder structure is different in the latest version of the SDK.

I changed the HWButtonTick (updated to new class names) handling to work with the new/replacement Release event in this version of the SDK.

Added IntersonArrayServerBMode.

Fixed typo in IntersonArrayServerRF.xml.